### PR TITLE
Fix hamburger menu covering mobile headings

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -253,13 +253,16 @@ body {
 
     .content h1 {
         font-size: 26px;
+        scroll-margin-top: 70px;
     }
 
     .content h2 {
         font-size: 22px;
+        scroll-margin-top: 70px;
     }
 
     .content h3 {
         font-size: 18px;
+        scroll-margin-top: 70px;
     }
 }


### PR DESCRIPTION
Added scroll-margin-top to h1, h2, and h3 elements on mobile viewports to prevent them from being obscured by the fixed hamburger menu when scrolling. This ensures headings maintain proper clearance from the top of the viewport.