### PR TITLE
Simplify hamburger menu to two lines

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,6 @@
     <div class="hamburger" id="hamburger">
         <span></span>
         <span></span>
-        <span></span>
     </div>
 
     <div class="container">

--- a/styles.css
+++ b/styles.css
@@ -38,15 +38,11 @@ body {
 }
 
 .hamburger.active span:nth-child(1) {
-    transform: rotate(-45deg) translate(-5px, 6px);
+    transform: rotate(-45deg) translate(-3px, 4px);
 }
 
 .hamburger.active span:nth-child(2) {
-    opacity: 0;
-}
-
-.hamburger.active span:nth-child(3) {
-    transform: rotate(45deg) translate(-5px, -6px);
+    transform: rotate(45deg) translate(-3px, -4px);
 }
 
 .container {


### PR DESCRIPTION
Modified the hamburger menu icon to display only two lines instead of three. Updated the active state animation to form an X shape with the two remaining lines.